### PR TITLE
init timeout

### DIFF
--- a/Net spoofer c+/NetConfig/kmboxNet.cpp
+++ b/Net spoofer c+/NetConfig/kmboxNet.cpp
@@ -98,6 +98,8 @@ int kmNet_init(char* ip, char* port, char* mac)
 	memset(&softkeyboard, 0, sizeof(softkeyboard));
 	err = sendto(sockClientfd, (const char*)&tx, sizeof(cmd_head_t), 0, (struct sockaddr*)&addrSrv, sizeof(addrSrv));
 	Sleep(20);
+	DWORD timeout = 3000; // ~ 3 second timeout
+	setsockopt(sockClientfd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout, sizeof(timeout));
 	int clen = sizeof(addrSrv);
 	err = recvfrom(sockClientfd, (char*)&rx, 1024, 0, (struct sockaddr*)&addrSrv, &clen);
 	if (err < 0)


### PR DESCRIPTION
This pull request introduces a small but important change to the `kmNet_init` function in the `kmboxNet.cpp` file to improve network communication reliability. Specifically, it sets a timeout for receiving data on the socket. This prevents any application using the KMNet library from encountering a threadlock due to a device connection failing.

* [`kmboxNet.cpp`](diffhunk://#diff-ce93ea65821514ffba4100fbfd9d4c3c917769c0478b35505288d3f3f08986f3R101-R102): Added a `SO_RCVTIMEO` socket option to set a 3-second timeout for receiving data, ensuring the function does not hang indefinitely if no response is received.